### PR TITLE
Added support for post requests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject throttle "0.1.2"
+(defproject throttle "0.1.3"
   :description "A request throttler library for Clojure."
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [http-kit "2.1.19"]


### PR DESCRIPTION
Added a post function able to POST some requests (with the same throttling abilities as the existing GET), with the possibility to pass data in the request too.

For simple post request without data, a request should look like: "http://my-server/my-path/1234"
For post requests with data, a request should look like: {:url "http://my-server/my-path/1234" :form-params {:param1 "value1" :param2 "value@"}}
